### PR TITLE
feat : CORS와 Limiting 필터 추가

### DIFF
--- a/src/main/java/com/hanghae/ecommerce/common/filter/CorsFilter.java
+++ b/src/main/java/com/hanghae/ecommerce/common/filter/CorsFilter.java
@@ -1,0 +1,31 @@
+package com.hanghae.ecommerce.common.filter;
+
+import java.io.IOException;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class CorsFilter implements Filter {
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+		HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+		HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+
+		httpServletResponse.setHeader("Access-Control-Allow-Origin", "*");
+		httpServletResponse.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+		httpServletResponse.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type");
+
+		if ("OPTIONS".equalsIgnoreCase(httpServletRequest.getMethod())) {
+			httpServletResponse.setStatus(HttpServletResponse.SC_OK);
+			return;
+		}
+
+		chain.doFilter(request, response);
+	}
+}

--- a/src/main/java/com/hanghae/ecommerce/common/filter/CustomFilter.java
+++ b/src/main/java/com/hanghae/ecommerce/common/filter/CustomFilter.java
@@ -1,0 +1,4 @@
+package com.hanghae.ecommerce.common.filter;
+
+public class CustomFilter {
+}

--- a/src/main/java/com/hanghae/ecommerce/common/filter/RateLimitingFilter.java
+++ b/src/main/java/com/hanghae/ecommerce/common/filter/RateLimitingFilter.java
@@ -1,0 +1,59 @@
+package com.hanghae.ecommerce.common.filter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class RateLimitingFilter implements Filter {
+
+	private final Map<String, RateLimiter> rateLimiters = new ConcurrentHashMap<>();
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws
+		IOException, ServletException {
+		HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+
+		String clientIp = request.getRemoteAddr();
+
+		RateLimiter rateLimiter = rateLimiters.computeIfAbsent(
+			clientIp, k -> new RateLimiter(5, TimeUnit.SECONDS)
+		);
+
+		if (rateLimiter.isLimitExceeded()) {
+			httpServletResponse.setStatus(429);
+			httpServletResponse.getWriter().write("지금은 처리할 수 없습니다. 잠시후 재시도 해주세요.");
+			return;
+		}
+
+		// 다음 필터로 요청을 전달
+		chain.doFilter(request, response);
+	}
+
+	private static class RateLimiter {
+		private final long limitIntervalMillis;
+		private long nextAllowedRequestTime;
+
+		public RateLimiter(int limitInterval, TimeUnit timeUnit) {
+			this.limitIntervalMillis = timeUnit.toMillis(limitInterval);
+			this.nextAllowedRequestTime = System.currentTimeMillis();
+		}
+
+		public boolean isLimitExceeded() {
+			long currentTimeMillis = System.currentTimeMillis();
+			if (currentTimeMillis < nextAllowedRequestTime) {
+				return true;
+			}
+			nextAllowedRequestTime = currentTimeMillis + limitIntervalMillis;
+			return false;
+		}
+	}
+}
+

--- a/src/main/java/com/hanghae/ecommerce/config/FilterConfig.java
+++ b/src/main/java/com/hanghae/ecommerce/config/FilterConfig.java
@@ -1,0 +1,24 @@
+package com.hanghae.ecommerce.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.hanghae.ecommerce.common.filter.CorsFilter;
+import com.hanghae.ecommerce.common.filter.RateLimitingFilter;
+
+import jakarta.servlet.Filter;
+
+@Configuration
+public class FilterConfig {
+
+	@Bean
+	public Filter corsFilter() {
+		return new CorsFilter();
+	}
+
+	@Bean
+	public Filter rateLimitingFilter() {
+		return new RateLimitingFilter();
+	}
+
+}


### PR DESCRIPTION
## 변경사항
- Step9 요구사항 구현
  - [x] Filter와 Interceptor 활용
  - [x] 모든 API 정상 작동 제공

## 리뷰 포인트  
- Interceptor는 이전 step에 구현해 이번 PR에는 포함되지 않았습니다. https://github.com/bangddong/Ecommerce/blob/main/src/main/java/com/hanghae/ecommerce/common/interceptor/RequestIdInterceptor.java
- Filter는 대중적인 CORS 처리와 이후 `대용량`이 같은 soruce에서 발생하는 중복 요청에 대한 처리 정도는 필요하지 않을까 싶어 rateLimit을 추가해보았습니다.
- SI에 재직중이다보니 임직원 대상으로 하는 서비스만 제공해봐서 filter나 interceptor는 CORS와 SSO 처리 여부 외 사용해본 경험이 없습니다... :(  채택한 시나리오가 `e-커머스이니 ~~한 걸 filter(interceptor)에 적용해볼 수 있지 않을까요?` 하는 키워드가 있으면 차주에 보완해서 적용해보겠습니다!
- Facade는 흐름 제어만하고 실제 비즈니스 로직은 서비스에서 처리하고 싶었으나 도메인간 결합이 있으면 안된다는 이유로 Facade가 더러워졌습니다 ... 이 createOrder를 리팩토링 할 수 있는 키워드가 있을까요?
https://github.com/bangddong/E-commerce/blob/main/src/main/java/com/hanghae/ecommerce/application/order/OrderFacade.java